### PR TITLE
Issue/54 - Go directly to /home

### DIFF
--- a/src/routes/home.svelte
+++ b/src/routes/home.svelte
@@ -14,12 +14,11 @@
     let searchResults = [];
     let searchText = "";
 
-    thingify();
-
     onMount(() => {
         const session = Session.json();
         console.log(session);
         name = session.member.name;
+        thingify();
     });
 
     async function thingify() {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -43,7 +43,7 @@
 <Column spacing="0">
 	<Section bg="bg">
 		<Title>pvd<span class="text-primary">:</span>things</Title>
-		<a href="/sign-in" hidden>Sign in</a>
+		<a href="/routes" hidden>Routes</a>
 	</Section>
 	<Section bg="bg">
 		<Spanner>

--- a/src/routes/routes.svelte
+++ b/src/routes/routes.svelte
@@ -1,0 +1,4 @@
+<nav>
+    <a href="/sign-in">Sign in</a>
+    <a href="/home">Home</a>
+</nav>


### PR DESCRIPTION
This fixes two issues:
1. We were previously unable to navigate directly to _/home_ if we hadn't already gone through the entire signin process.
2. We were intermittently getting an error about _fetch_ not being defined. I think I fixed this by moving the call to `thingify` into `onMount()`.